### PR TITLE
Fix compilation with gcc-10.2.0

### DIFF
--- a/xpp/xtalk/xtalk_sync.c
+++ b/xpp/xtalk/xtalk_sync.c
@@ -60,7 +60,7 @@ union XTALK_PDATA(XTALK) {
 	MEMBER(XTALK, ACK);
 	MEMBER(XTALK, PROTO_GET);
 	MEMBER(XTALK, PROTO_GET_REPLY);
-} PACKED members;
+} PACKED _members;
 
 const struct xtalk_protocol	xtalk_sync_proto = {
 	.name	= "XTALK-SYNC",


### PR DESCRIPTION
/bin/sh ../libtool  --tag=CC   --mode=link gcc -I. -I./xtalk/include  -Wall  -g -O2 -lusb-1.0  -o astribank_tool astribank_tool-astribank_tool.o libastribank.la -lpthread -lm
libtool: link: gcc -I. -I./xtalk/include -Wall -g -O2 -o astribank_tool astribank_tool-astribank_tool.o  ./.libs/libastribank.a -lusb-1.0 -lpthread -lm
/usr/bin/ld: ./.libs/libastribank.a(libxtalk_la-xtalk_sync.o):/space/home/laforge/projects/git/dahdi-tools/xpp/xtalk/xtalk_sync.c:63: multiple definition of `members'; ./.libs/libastribank.a(libastribank_la-mpptalk.o):/space/home/laforge/projects/git/dahdi-tools/xpp/mpptalk.c:240: first defined here

Change-Id: I1d6f46874f74e1dfc70cabf7c4a8b8cdae9af4fa